### PR TITLE
Allow updating of dataloader configuration.json from the UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,27 @@ This App Function allows us to retrieve the last known status of a given pipelin
  - Flyway is used to manage the state of the database, that's all. This application does not otherwise interact with the database
  - SQL Scripts for updating the Database can be found here:  /src/main/resources/db/migration
  
+ ## Additional Notes
+  - The dataloader storage container needs to be manually updated once initially, to set users that have access to containers. See example below.
+  - Only system administrators should have access to the Dataloader container
+  - Storage containers only get created when that application is booted up (initialized)
+  - New containers need to be manually created in Azure
+  - Ex:
+  ```json
+{
+  "businessUnits": [
+    {
+      "containerName": "demo",
+      "businessName": "Demo Business Unit",
+      "users": []
+    },
+    {
+      "containerName": "dataloader",
+      "businessName": "Dataloader",
+      "users": [
+        "admin@foo.com" 
+      ]
+    }
+  ]
+}
+```

--- a/src/main/java/gov/ita/dataloader/ingest/IngestController.java
+++ b/src/main/java/gov/ita/dataloader/ingest/IngestController.java
@@ -102,7 +102,6 @@ public class IngestController {
   @GetMapping(value = "/api/container-metadata", produces = MediaType.APPLICATION_JSON_VALUE)
   public List<BlobMetaData> getStorageMetadata(@RequestParam("containerName") String containerName) {
     return storage.getBlobMetadata(containerName, true).stream()
-      .filter(blobMetaData -> !blobMetaData.getFileName().equals("configuration.json"))
       .filter(blobMetaData -> !blobMetaData.getFileName().startsWith("translated"))
       .map(this::handleLegacyBlobMetadata)
       .collect(Collectors.toList());

--- a/src/main/java/gov/ita/dataloader/ingest/configuration/DataloaderConfig.java
+++ b/src/main/java/gov/ita/dataloader/ingest/configuration/DataloaderConfig.java
@@ -1,5 +1,6 @@
 package gov.ita.dataloader.ingest.configuration;
 
+import gov.ita.dataloader.business_unit.BusinessUnit;
 import lombok.Data;
 
 import java.util.List;
@@ -7,4 +8,5 @@ import java.util.List;
 @Data
 public class DataloaderConfig {
   public List<DataSetConfig> dataSetConfigs;
+  public List<BusinessUnit> businessUnits;
 }

--- a/src/main/java/gov/ita/dataloader/storage/StorageInitializer.java
+++ b/src/main/java/gov/ita/dataloader/storage/StorageInitializer.java
@@ -20,11 +20,12 @@ public class StorageInitializer {
   public void init() {
     List<String> newContainers = new ArrayList<>();
     newContainers.add("dataloader");
+    newContainers.add("demo");
+    newContainers.add("fta-tariff-rates");
     newContainers.add("otexa");
     newContainers.add("select-usa");
-    newContainers.add("fta-tariff-rates");
-    newContainers.add("demo");
     newContainers.add("siat");
+    newContainers.add("sima");
 
     Set<String> existingContainers = storage.getContainerNames();
 

--- a/src/main/resources/fixtures/dataloader.json
+++ b/src/main/resources/fixtures/dataloader.json
@@ -19,6 +19,21 @@
       "containerName": "demo",
       "businessName": "Demo Business Unit",
       "users": []
+    },
+    {
+      "containerName": "siat",
+      "businessName": "Survey of International Air Travelers",
+      "users": []
+    },
+    {
+      "containerName": "sima",
+      "businessName": "SIMA",
+      "users": []
+    },
+    {
+      "containerName": "dataloader",
+      "businessName": "Dataloader",
+      "users": []
     }
   ]
 }


### PR DESCRIPTION
- Updated README.md with notes regarding the dataloader storage container
- Decided not to filter out the configuration.json so users may see snapshots of previous configurations